### PR TITLE
Updates for Sentry 10

### DIFF
--- a/msteams/plugin.py
+++ b/msteams/plugin.py
@@ -44,7 +44,7 @@ class TeamsPlugin(notify.NotificationPlugin):
                 'type': 'bool',
                 'required': False,
                 'help': 'Show Event Tags in Teams Message',
-}
+            }
         ]
 
     def notify(self, notification):
@@ -61,12 +61,19 @@ class TeamsPlugin(notify.NotificationPlugin):
             return
 
         webhook_url = self.get_option('webhook_url', project)
-        title = event.message_short.encode('utf-8')
         project_name = project.get_full_name().encode('utf-8')
-        error_message = event.error().encode('utf-8')
         notification_link = self.create_markdown_link('Click Here',
                                                       self.add_notification_referrer_param(
                                                           group.get_absolute_url()))
+        
+        try:
+            # Sentry 9
+            title = event.message_short.encode('utf-8')
+            error_message = event.error().encode('utf-8')
+        except AttributeError:
+            # Sentry 10
+            title = event.title.encode('utf-8')
+            error_message = event.message.encode('utf-8')
 
         message_facts = []
 

--- a/msteams/plugin.py
+++ b/msteams/plugin.py
@@ -117,7 +117,7 @@ class TeamsPlugin(notify.NotificationPlugin):
             try:
                 # Sentry 9
                 sentry_tags = event.get_tags()
-            except:
+            except AttributeError:
                 # Sentry 10
                 sentry_tags = event.tags
             if sentry_tags:

--- a/msteams/plugin.py
+++ b/msteams/plugin.py
@@ -114,7 +114,12 @@ class TeamsPlugin(notify.NotificationPlugin):
 
         if self.get_option('show_tags', project):
             tags = []
-            sentry_tags = event.get_tags()
+            try:
+                # Sentry 9
+                sentry_tags = event.get_tags()
+            except:
+                # Sentry 10
+                sentry_tags = event.tags
             if sentry_tags:
                 sentry_tag_tuples = ((tagstore.get_tag_key_label(tagname), tagstore.get_tag_value_label(tagname, tagvalue))
                                      for tagname, tagvalue in sentry_tags)


### PR DESCRIPTION
Closes #7 and enables Sentry 10 to use this as a 'legacy' plugin.