### PR TITLE
fix(plugin): Handle raise_exception argument

### DIFF
--- a/msteams/plugin.py
+++ b/msteams/plugin.py
@@ -47,7 +47,7 @@ class TeamsPlugin(notify.NotificationPlugin):
             }
         ]
 
-    def notify(self, notification):
+    def notify(self, notification, raise_exception = None):
         """
         notify
         Send Event Notifications


### PR DESCRIPTION
Sentry >v10.0.0 calls `notify` with a `raise_exception` argument that needs to be taken into account. Fixes https://github.com/Neko-Design/sentry-msteams/issues/9